### PR TITLE
Fix Makefile target for building binaries

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,6 +8,19 @@ on:
     - main
 
 jobs:
+  build:
+    runs-on: [ubuntu-latest]
+    steps:
+    - name: Set up Go 1.16
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.16
+    - name: Check-out code
+      uses: actions/checkout@v2
+    - name: Build binaries
+      run: |
+        make bin
+
   test:
     runs-on: [ubuntu-latest]
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@
 .vscode/
 
 .golangci-bin
+
+bin

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,12 @@ LDFLAGS            :=
 GOFLAGS            :=
 BINDIR             ?= $(CURDIR)/bin
 
-.PHONY: resource-auditing
-resource-auditing:
+all: bin
+
+.PHONY: bin
+bin:
 	@mkdir -p $(BINDIR)
-	GOOS=linux $(GO) build -o $(BINDIR) $(GOFLAGS) -ldflags '$(LDFLAGS)' antrea.io/resource-auditing
+	GOOS=linux $(GO) build -o $(BINDIR) $(GOFLAGS) -ldflags '$(LDFLAGS)' antrea.io/resource-auditing/cmd/...
 
 .PHONY: test
 test:


### PR DESCRIPTION
It was trying to "build" antrea.io/resource-auditing, which is not a
valid package, and failing. We also add a new CI job to make sure
binaries can be built successfully.

Signed-off-by: Antonin Bas <abas@vmware.com>