### PR TITLE
Add client-side CLI and server-side handlers for tag/rollback features

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -14,6 +14,160 @@
 
 package main
 
-func main() {
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path"
 
+	"github.com/spf13/cobra"
+
+	"antrea.io/resource-auditing/pkg/types"
+)
+
+// tag flags
+var tagAuthor, tagEmail string
+
+// rollback flags
+var rollbackTag, rollbackSHA string
+
+// shared flags
+var serverAddr string
+
+var commandName = path.Base(os.Args[0])
+
+var rootCmd = &cobra.Command{
+	Use:  commandName,
+	Long: commandName + " is the command line tool for managing the auditing resource repository",
+}
+
+var tagCmd = &cobra.Command{
+	Use:   "tag create tag_name commit_sha [-a author] [-e email]\n   or: tag delete tag_name",
+	Short: "tags commits in the repository",
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) < 2 {
+			return fmt.Errorf("too few args")
+		}
+		if args[0] == "create" {
+			if len(args) != 3 {
+				return fmt.Errorf("unexpected number of args for tag create")
+			}
+		} else if args[0] == "delete" {
+			if len(args) != 2 {
+				return fmt.Errorf("unexpected number of args for tag delete")
+			}
+		} else {
+			return fmt.Errorf("unsupported keyword (not create or delete)")
+		}
+		return nil
+	},
+	Run: runTag,
+}
+
+var rollbackCmd = &cobra.Command{
+	Use:   "rollback -t tag_name | -s commit_sha",
+	Short: "rollback to the specified commit by tag name or SHA",
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 0 {
+			return fmt.Errorf("unexpected number of args for rollback")
+		}
+		if (rollbackTag != "") == (rollbackSHA != "") {
+			return fmt.Errorf("must specify exactly one of -t or -s")
+		}
+		return nil
+	},
+	Run: runRollback,
+}
+
+func runTag(cmd *cobra.Command, args []string) {
+	var request types.TagRequest
+	if args[0] == "create" {
+		request = types.TagRequest{
+			Type:   types.TagCreate,
+			Tag:    args[1],
+			Sha:    args[2],
+			Author: tagAuthor,
+			Email:  tagEmail,
+		}
+	} else {
+		request = types.TagRequest{
+			Type: types.TagDelete,
+			Tag:  args[1],
+		}
+	}
+	j, err := json.Marshal(request)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	url := "http://" + serverAddr + "/tag"
+	// #nosec G107: need user-provided URL for server
+	resp, err := http.Post(url, "application/json", bytes.NewBuffer(j))
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	if resp.StatusCode == http.StatusBadRequest || resp.StatusCode == http.StatusInternalServerError {
+		fmt.Println("Error encountered while processing tag request")
+		return
+	}
+	fmt.Println(string(body))
+}
+
+func runRollback(cmd *cobra.Command, args []string) {
+	request := types.RollbackRequest{
+		Tag: rollbackTag,
+		Sha: rollbackSHA,
+	}
+	j, err := json.Marshal(request)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	url := "http://" + serverAddr + "/rollback"
+	// #nosec G107: need user-provided URL for server
+	resp, err := http.Post(url, "application/json", bytes.NewBuffer(j))
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	if resp.StatusCode == http.StatusBadRequest || resp.StatusCode == http.StatusInternalServerError {
+		fmt.Println("Error encountered while processing rollback request")
+		return
+	}
+	fmt.Println(string(body))
+}
+
+func init() {
+	tagCmd.Flags().StringVarP(&tagAuthor, "author", "a", "no-author", "tag author")
+	tagCmd.Flags().StringVarP(&tagEmail, "email", "e", "default@audit.io", "tag email")
+	tagCmd.Flags().StringVarP(&serverAddr, "server-addr", "", "localhost:8080", "address to send request to")
+	rootCmd.AddCommand(tagCmd)
+	rollbackCmd.Flags().StringVarP(&rollbackTag, "tag", "t", "", "name of tag to rollback to")
+	rollbackCmd.Flags().StringVarP(&rollbackSHA, "sha", "s", "", "commit hash to rollback to")
+	rollbackCmd.Flags().StringVarP(&serverAddr, "server-addr", "", "localhost:8080", "address to send request to")
+	rootCmd.AddCommand(rollbackCmd)
+}
+
+func main() {
+	err := rootCmd.Execute()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 }

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -23,23 +23,23 @@ import (
 	"antrea.io/resource-auditing/pkg/webhook"
 )
 
+func processArgs() {
+	flag.StringVar(&portFlag, "p", "8080", "specifies port that audit webhook listens on")
+	flag.StringVar(&dirFlag, "d", "", "directory where resource repository is created, defaults to current working directory")
+	flag.Parse()
+}
+
 var (
 	portFlag string
 	dirFlag  string
 )
-
-func processArgs() {
-	flag.StringVar(&portFlag, "p", "8080", "specifies port that audit webhook listens on")
-	flag.StringVar(&dirFlag, "d", "", "specifies directory where resource repository is created, defaults to current working directory")
-	flag.Parse()
-}
 
 func main() {
 	klog.InitFlags(nil)
 	processArgs()
 	k8s, err := gitops.NewKubernetes()
 	if err != nil {
-		klog.ErrorS(err, "unable to create new kube clients")
+		klog.ErrorS(err, "unable to create kube client")
 		return
 	}
 	cr, err := gitops.SetupRepo(k8s, gitops.StorageModeDisk, dirFlag)
@@ -47,7 +47,7 @@ func main() {
 		klog.ErrorS(err, "unable to set up resource repository")
 		return
 	}
-	if err := webhook.ReceiveEvents(dirFlag, portFlag, cr); err != nil {
+	if err := webhook.ReceiveEvents(portFlag, cr); err != nil {
 		klog.ErrorS(err, "an error occurred while running the audit webhook service")
 		return
 	}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-git/go-billy/v5 v5.3.1
 	github.com/go-git/go-git/v5 v5.4.2
+	github.com/spf13/cobra v1.1.1
 	github.com/stretchr/testify v1.7.0
 	k8s.io/api v0.21.3
 	k8s.io/apimachinery v0.21.3

--- a/go.sum
+++ b/go.sum
@@ -354,6 +354,7 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
@@ -548,6 +549,7 @@ github.com/spf13/afero v1.4.1/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
+github.com/spf13/cobra v1.1.1 h1:KfztREH0tPxJJ+geloSLaAkaPkr4ki2Er5quFV1TDo4=
 github.com/spf13/cobra v1.1.1/go.mod h1:WnodtKOvamDL/PwE2M4iKs8aMDBZ5Q5klgD3qfVJQMI=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=

--- a/pkg/gitops/audit_handler.go
+++ b/pkg/gitops/audit_handler.go
@@ -40,7 +40,7 @@ func (cr *CustomRepo) HandleEventList(jsonstring []byte) error {
 			continue
 		}
 		if cr.RollbackMode {
-			return fmt.Errorf("audit skipped - rollback in progress")
+			return fmt.Errorf("rollback in progress")
 		}
 		if err = cr.HandleEvent(event); err != nil {
 			return fmt.Errorf("could not handle event: %w", err)
@@ -61,7 +61,7 @@ func (cr *CustomRepo) HandleEvent(event auditv1.Event) error {
 		if err := cr.AddAndCommit(user, email, "Created "+message); err != nil {
 			return fmt.Errorf("could not add/commit add operation: %w", err)
 		}
-		klog.V(2).InfoS("successfully created resource: %s", message)
+		klog.V(2).InfoS("successfully created resource", "resource", message)
 	case "patch":
 		if err := cr.modifyFile(event); err != nil {
 			return fmt.Errorf("could not update resource: %w", err)
@@ -69,7 +69,7 @@ func (cr *CustomRepo) HandleEvent(event auditv1.Event) error {
 		if err := cr.AddAndCommit(user, email, "Updated "+message); err != nil {
 			return fmt.Errorf("could not add/commit patch operation: %w", err)
 		}
-		klog.V(2).InfoS("successfully updated resource: %s", message)
+		klog.V(2).InfoS("successfully updated resource", "resource", message)
 	case "delete":
 		if err := cr.deleteFile(event); err != nil {
 			return fmt.Errorf("could not delete resource: %w", err)
@@ -77,7 +77,7 @@ func (cr *CustomRepo) HandleEvent(event auditv1.Event) error {
 		if err := cr.AddAndCommit(user, email, "Deleted "+message); err != nil {
 			return fmt.Errorf("could not add/commit the delete operation: %w", err)
 		}
-		klog.V(2).InfoS("successfully deleted resource: %s", message)
+		klog.V(2).InfoS("successfully deleted resource", "resource", message)
 	default:
 		return fmt.Errorf("must be create/patch/delete operation")
 	}

--- a/pkg/gitops/audit_handler_test.go
+++ b/pkg/gitops/audit_handler_test.go
@@ -40,7 +40,7 @@ func TestHandleEventList(t *testing.T) {
 	cr.RollbackMode = true
 	err = cr.HandleEventList(jsonstring)
 	cr.RollbackMode = false
-	assert.EqualError(t, err, "audit skipped - rollback in progress")
+	assert.EqualError(t, err, "rollback in progress")
 
 	for i := 1; i < 4; i++ {
 		filename := fmt.Sprintf("%s%d%s", "../../test/files/incorrect-audit-log-", i, ".txt")

--- a/pkg/gitops/rollback.go
+++ b/pkg/gitops/rollback.go
@@ -59,7 +59,7 @@ func (cr *CustomRepo) HashToCommit(commitSha string) (*object.Commit, error) {
 	return commit, nil
 }
 
-func (cr *CustomRepo) RollbackRepo(targetCommit *object.Commit) error {
+func (cr *CustomRepo) RollbackRepo(targetCommit *object.Commit) (string, error) {
 	cr.Mutex.Lock()
 	defer cr.Mutex.Unlock()
 
@@ -70,39 +70,39 @@ func (cr *CustomRepo) RollbackRepo(targetCommit *object.Commit) error {
 	// Get patch between head and target commit
 	w, err := cr.Repo.Worktree()
 	if err != nil {
-		return fmt.Errorf("unable to get git worktree from repository: %w", err)
+		return "", fmt.Errorf("unable to get git worktree from repository: %w", err)
 	}
 	h, err := cr.Repo.Head()
 	if err != nil {
-		return fmt.Errorf("unable to get repo head: %w", err)
+		return "", fmt.Errorf("unable to get repo head: %w", err)
 	}
 	headCommit, err := cr.Repo.CommitObject(h.Hash())
 	if err != nil {
-		return fmt.Errorf("unable to get head commit: %w", err)
+		return "", fmt.Errorf("unable to get head commit: %w", err)
 	}
 	patch, err := headCommit.Patch(targetCommit)
 	if err != nil {
-		return fmt.Errorf("unable to get patch between commits: %w", err)
+		return "", fmt.Errorf("unable to get patch between commits: %w", err)
 	}
 
 	// Must do cluster delete requests before resetting in order to be able to read metadata from files
 	if err := cr.doDeletePatch(patch); err != nil {
-		return fmt.Errorf("could not patch cluster to old commit state (delete phase): %w", err)
+		return "", fmt.Errorf("could not patch cluster to old commit state (delete phase): %w", err)
 	}
 
 	// Update repo using resets
 	err = resetWorktree(w, targetCommit.Hash, git.HardReset)
 	if err != nil {
-		return fmt.Errorf("unable to hard reset repo: %w", err)
+		return "", fmt.Errorf("unable to hard reset repo: %w", err)
 	}
 	err = resetWorktree(w, h.Hash(), git.SoftReset)
 	if err != nil {
-		return fmt.Errorf("unable to hard reset repo: %w", err)
+		return "", fmt.Errorf("unable to hard reset repo: %w", err)
 	}
 
 	// Must similarly do cluster update/create requests after resetting
 	if err := cr.doCreateUpdatePatch(patch); err != nil {
-		return fmt.Errorf("could not patch cluster to old commit state (create/update phase): %w", err)
+		return "", fmt.Errorf("could not patch cluster to old commit state (create/update phase): %w", err)
 	}
 
 	// Finally commit changes to repo after cluster updates
@@ -110,11 +110,11 @@ func (cr *CustomRepo) RollbackRepo(targetCommit *object.Commit) error {
 	email := "system@audit.antrea.io"
 	message := "Rollback to commit " + targetCommit.Hash.String()
 	if err := cr.AddAndCommit(username, email, message); err != nil {
-		return fmt.Errorf("error while committing rollback: %w", err)
+		return "", fmt.Errorf("error while committing rollback: %w", err)
 	}
 	cr.RollbackMode = false
-	klog.V(2).InfoS("rollback successful", "targetCommit", targetCommit.Hash.String())
-	return nil
+	klog.V(2).InfoS("Rollback successful", "targetCommit", targetCommit.Hash.String())
+	return targetCommit.Hash.String(), nil
 }
 
 func resetWorktree(w *git.Worktree, hash plumbing.Hash, mode git.ResetMode) error {

--- a/pkg/gitops/rollback_test.go
+++ b/pkg/gitops/rollback_test.go
@@ -106,7 +106,7 @@ func TestRollback(t *testing.T) {
 		Email: "test@antrea.audit.io",
 		When:  time.Now(),
 	}
-	err = cr.TagCommit(h.Hash().String(), "test-tag", testSig)
+	_, err = cr.TagCommit(h.Hash().String(), "test-tag", testSig)
 	assert.NoError(t, err, "unable to create new tag")
 
 	// Create, update, and delete a resource
@@ -153,7 +153,7 @@ func TestRollback(t *testing.T) {
 	// Attempt rollback
 	commit, err := cr.TagToCommit("test-tag")
 	assert.NoError(t, err, "could not retrieve commit from tag")
-	err = cr.RollbackRepo(commit)
+	_, err = cr.RollbackRepo(commit)
 	assert.NoError(t, err, "rollback failed")
 
 	// Check latest commit

--- a/pkg/gitops/tagging.go
+++ b/pkg/gitops/tagging.go
@@ -24,29 +24,29 @@ import (
 	"k8s.io/klog/v2"
 )
 
-func (cr *CustomRepo) TagCommit(commit_sha string, tag string, tagger *object.Signature) error {
-	hash := plumbing.NewHash(commit_sha)
+func (cr *CustomRepo) TagCommit(commitSha string, tag string, tagger *object.Signature) (string, error) {
+	hash := plumbing.NewHash(commitSha)
 	_, err := cr.Repo.CommitObject(hash)
 	if err != nil {
-		return fmt.Errorf("unable to get commit object: %w", err)
+		return "", fmt.Errorf("unable to get commit object: %w", err)
 	}
 	if err = setTag(cr.Repo, hash, tag, tagger); err != nil {
-		return fmt.Errorf("unable to create tag: %w", err)
+		return "", fmt.Errorf("unable to create tag: %w", err)
 	}
-	klog.V(2).InfoS("tag created", "tagName", tag, "commit", commit_sha)
-	return nil
+	klog.V(2).InfoS("Tag created", "tagName", tag, "commit", commitSha)
+	return commitSha, nil
 }
 
-func (cr *CustomRepo) RemoveTag(tag string) error {
+func (cr *CustomRepo) RemoveTag(tag string) (string, error) {
 	if err := cr.Repo.DeleteTag(tag); err != nil {
-		return fmt.Errorf("unable to delete tag: %w", err)
+		return "", fmt.Errorf("unable to delete tag: %w", err)
 	}
-	klog.V(2).InfoS("tag deleted", "tagName", tag)
-	return nil
+	klog.V(2).InfoS("Tag deleted", "tagName", tag)
+	return tag, nil
 }
 
-func setTag(r *git.Repository, commit_sha plumbing.Hash, tag string, tagger *object.Signature) error {
-	_, err := r.CreateTag(tag, commit_sha, &git.CreateTagOptions{
+func setTag(r *git.Repository, commitSha plumbing.Hash, tag string, tagger *object.Signature) error {
+	_, err := r.CreateTag(tag, commitSha, &git.CreateTagOptions{
 		Tagger:  tagger,
 		Message: tag,
 	})

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -1,0 +1,21 @@
+package types
+
+type TagRequestType string
+
+const (
+	TagCreate TagRequestType = "create"
+	TagDelete TagRequestType = "delete"
+)
+
+type TagRequest struct {
+	Type   TagRequestType `json:"type,omitempty"`
+	Tag    string         `json:"tag,omitempty"`
+	Sha    string         `json:"sha,omitempty"`
+	Author string         `json:"author,omitempty"`
+	Email  string         `json:"email,omitempty"`
+}
+
+type RollbackRequest struct {
+	Tag string `json:"tag,omitempty"`
+	Sha string `json:"sha,omitempty"`
+}


### PR DESCRIPTION
Also changes some tag/rollback function signatures to return the tag/commit on success so that handlers can write success messages to the response bodies.