### PR TITLE
Hardcodes "auditctl" as CLI root command

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -21,7 +21,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
-	"path"
 
 	"github.com/spf13/cobra"
 
@@ -37,7 +36,7 @@ var rollbackTag, rollbackSHA string
 // shared flags
 var serverAddr string
 
-var commandName = path.Base(os.Args[0])
+var commandName = "auditctl"
 
 var rootCmd = &cobra.Command{
 	Use:  commandName,


### PR DESCRIPTION
Corrects unaddressed comment mentioned in https://github.com/antrea-io/resource-auditing/pull/9